### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ module "dcos-lb-masters" {
 | instances | List of instance IDs | list | n/a | yes |
 | num\_instances | How many instances should be created | string | n/a | yes |
 | subnet\_ids | List of subnet IDs created in this network | list | n/a | yes |
+| adminrouter\_grpc\_proxy\_port |  | string | `"12379"` | no |
 | disable | Do not create load balancer and its resources | string | `"false"` | no |
 | https\_acm\_cert\_arn | ACM certifacte to be used. | string | `""` | no |
 | internal | This ELB is internal only | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,11 @@ module "masters" {
   disable            = "${var.disable}"
   name_prefix        = "${var.name_prefix}"
   load_balancer_type = "application"
+  additional_listener = [{
+    port = "${var.adminrouter_grpc_proxy_port}"
+    protocol = "https"
+    certificate_arn = "${coalesce(var.https_acm_cert_arn, "selfsigned")}"
+  }]
 
   tags = "${var.tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -47,9 +47,10 @@ module "masters" {
   disable            = "${var.disable}"
   name_prefix        = "${var.name_prefix}"
   load_balancer_type = "application"
+
   additional_listener = [{
-    port = "${var.adminrouter_grpc_proxy_port}"
-    protocol = "https"
+    port            = "${var.adminrouter_grpc_proxy_port}"
+    protocol        = "https"
     certificate_arn = "${coalesce(var.https_acm_cert_arn, "selfsigned")}"
   }]
 

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,8 @@ variable "internal" {
 variable "num_instances" {
   description = "How many instances should be created"
 }
+
+variable "adminrouter_grpc_proxy_port" {
+    description = ""
+    default     = 12379
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,6 @@ variable "num_instances" {
 }
 
 variable "adminrouter_grpc_proxy_port" {
-    description = ""
-    default     = 12379
+  description = ""
+  default     = 12379
 }


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476